### PR TITLE
Tidy up button code

### DIFF
--- a/Main/MainScene.tscn
+++ b/Main/MainScene.tscn
@@ -35,16 +35,14 @@ script = null
 
 [node name="CharacterBody3D" parent="." instance=ExtResource("2_bedd3")]
 
-[node name="RedButton" parent="." node_paths=PackedStringArray("door", "door2") instance=ExtResource("3_j1g3y")]
+[node name="RedButton" parent="." node_paths=PackedStringArray("doors") instance=ExtResource("3_j1g3y")]
 transform = Transform3D(-0.000191971, -1, 0, 1, -0.000191971, 0, 0, 0, 1, 1.14977, 1.44024, 0)
-door = NodePath("../Cube2")
-door2 = NodePath("../Root")
+doors = [NodePath("../Door_1"), NodePath("../Door_2")]
 
-[node name="Cube2" parent="." instance=ExtResource("1_5f1dg")]
-unique_name_in_owner = true
+[node name="Door_1" parent="." instance=ExtResource("1_5f1dg")]
 transform = Transform3D(0.348, 0, 0, 0, 2.622, 0, 0, 0, 2.07, 2.198, 0.5, 2.25)
 
-[node name="Root" parent="." instance=ExtResource("4_6ryya")]
+[node name="Door_2" parent="." instance=ExtResource("4_6ryya")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1.50868, 2.14605, 0.354638, -1.74181)
 
 [node name="Cube3" parent="." instance=ExtResource("1_5f1dg")]
@@ -61,7 +59,3 @@ script = null
 
 [node name="ReflectionProbe" type="ReflectionProbe" parent="."]
 size = Vector3(30, 3, 30)
-
-[editable path="RedButton"]
-[editable path="Cube2"]
-[editable path="Root"]

--- a/Objects/button.gd
+++ b/Objects/button.gd
@@ -1,28 +1,33 @@
 extends Node3D
 
-@export var door : Door
-@export var door2 : Door
-#@onready var Ray = $RayCast3D
-@onready var Area = $Area3D
+@export var doors: Array[Door]
 
-# Replace "Player" with the actual class name of your player objec
+var is_player_nearby: bool
+
+func _ready():
+	if doors.size() > 1:
+		return
+	## Prevent crashing by checking if any doors are in the list.
+	## This would cause crashes if we were to toggle nothing (i.e list is there, but nothing is in it.)
+	assert("No door was set in the doors array, quitting.")
+
+
 func _input(event):
-	if event.is_action_pressed("interact"):
-		var overlapping_bodies = Area.get_overlapping_bodies()
-	
-		for A in overlapping_bodies:
-			if A is _Player:  # Replace "Player" with the actual class name of your player object
-				door.toggle()
-				door2.toggle()
-				break  # Exit the loop if you've found the player
-#		if Ray.is_colliding():
-#			var collider = Ray.get_collider()
-#			if collider is _Player:
-#				print("RAY colliding too")
+	if event.is_action_pressed("interact") && is_player_nearby:
+		toggle_doors()
 
-	pass
+## For each door in the list of doors, toggle them.
+func toggle_doors():
+	for door in doors:
+		door.toggle()
 
+## Set player is near to true when player has entered the area
+func _on_area_3d_body_entered(body):
+	if body is _Player:
+		is_player_nearby = true
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#	pass
+## Set player is near to false when player has exited the area
+func _on_area_3d_body_exited(body):
+	if body is _Player:
+		is_player_nearby = false
+

--- a/Objects/red_button.tscn
+++ b/Objects/red_button.tscn
@@ -54,3 +54,6 @@ collision_mask = 7
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
 shape = SubResource("BoxShape3D_qamjf")
+
+[connection signal="body_entered" from="Area3D" to="." method="_on_area_3d_body_entered"]
+[connection signal="body_exited" from="Area3D" to="." method="_on_area_3d_body_exited"]


### PR DESCRIPTION
This pull request makes the following changes:
- Uses an array of doors to toggle them instead of having hard references.
- Uses built-in area signals instead of checking if anything is in the area every time interact is pressed.
- Deletes the unused node in Player.tscn.
- Turns off editable children for nodes that don't need it.